### PR TITLE
Fix command for publish migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The package will automatically register itself.
 You can publish the migration with:
 
 ```bash
-php artisan vendor:publish --provider=BeyondCode\Vouchers\VouchersServiceProvider --tag="migrations"
+php artisan vendor:publish --provider="BeyondCode\Vouchers\VouchersServiceProvider" --tag="migrations"
 ```
 
 After the migration has been published you can create the vouchers table by running the migrations:


### PR DESCRIPTION
Before
```bash
php artisan vendor:publish --provider=BeyondCode\Vouchers\VouchersServiceProvider --tag="migrations"
Publishing complete.
```

After
```bash
php artisan vendor:publish --provider="BeyondCode\Vouchers\VouchersServiceProvider" --tag="migrations"
Copied File [/vendor/beyondcode/laravel-vouchers/database/migrations/create_vouchers_table.php.stub] To [/database/migrations/2020_02_05_224810_create_vouchers_table.php]
Publishing complete.
```