### PR TITLE
Remove duplication when creating vouchers for models

### DIFF
--- a/src/Traits/HasVouchers.php
+++ b/src/Traits/HasVouchers.php
@@ -35,8 +35,6 @@ trait HasVouchers
      */
     public function createVoucher(array $data = [], $expires_at = null)
     {
-        $vouchers = Vouchers::create($this, 1, $data, $expires_at);
-
-        return $vouchers[0];
+        return $this->createVouchers(1, $data, $expires_at)[0];
     }
 }


### PR DESCRIPTION
This PR removes duplication in the `HasVouchers` trait. 