### PR TITLE
Minor README.md update to ensure instructions are correct.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ php artisan migrate
 You can publish the config-file with:
 
 ```bash
-php artisan vendor:publish --provider=BeyondCode\Vouchers\VouchersServiceProvider --tag="config"
+php artisan vendor:publish --provider="BeyondCode\Vouchers\VouchersServiceProvider" --tag="config"
 ```
 
 This is the contents of the published config file:


### PR DESCRIPTION
Changed the instruction for publishing the config file as using it without the quotes emits a:

> No publishable resources for tag [config]